### PR TITLE
Add hard mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,5 @@ go install github.com/JeremyLoy/termle@latest
 termle # plays current day
 termle -random # plays a random day
 termle -day 215 # play a day by number
+termle -hard # play in hard mode (any revealed hints must be used in subsequent guesses)
 ```

--- a/termle.go
+++ b/termle.go
@@ -140,7 +140,7 @@ func prompt() {
 	fmt.Print(">")
 }
 
-func newGame(day int, hardmode bool) *game {
+func newGame(day int, hardMode bool) *game {
 	b := make([][]cell, 6)
 	for i := range b {
 		b[i] = make([]cell, 5)
@@ -157,7 +157,7 @@ func newGame(day int, hardmode bool) *game {
 		turnsRemaining: 6,
 		complete:       false,
 		won:            false,
-		hardMode:       hardmode,
+		hardMode:       hardMode,
 		hints: hints{
 			yellow: make(map[rune]bool),
 			green:  [5]rune{},

--- a/termle.go
+++ b/termle.go
@@ -182,7 +182,7 @@ func (g *game) checkHints(guess string) error {
 	var emptyRune rune
 	for i, greenHint := range g.hints.green {
 		if greenHint != emptyRune && greenHint != rune(guess[i]) {
-			return fmt.Errorf("position %d must contain \"%s\"", i, string(greenHint))
+			return fmt.Errorf("position %d must contain \"%s\"", i+1, string(greenHint))
 		}
 	}
 


### PR DESCRIPTION
Thanks for sharing this! Had the same idea and I'm glad I found that I'm not alone wanting to play wordle on my terminal. 🙂 

I often play wordle in hard mode, which means that "yellow" and "green" hints must appear in subsequent attempts. Makes for a more challenging game since you cannot "cheat" by trying 10 unique letters on your first two tries. 

My approach was to create a new `hints` data structure within `game`, so the logic can be isolated and doesn't need to check the board directly. Let me know what do you think. 
